### PR TITLE
Add project type to slack name

### DIFF
--- a/documentation/project-organization/slack.markdown
+++ b/documentation/project-organization/slack.markdown
@@ -9,7 +9,7 @@ nav_order: 1
 
 Slack channels are used for different purposes and the name of those channels should consistently reflect the usage for that channel. As a result, we have adopted the following convention:
 
-`[i-]<season><2 digit year>-<project>-[mgmt/inst]`
+`[i-]<season><2 digit year>-[type]-<project>-[mgmt/inst]`
 
 ## Explanation
 * angle brackets (`<>`) mean the information needs to be fillled in but is required
@@ -17,6 +17,7 @@ Slack channels are used for different purposes and the name of those channels sh
 * `[i-]` -- indictates that the channel is *internal* and *only* the project team no third parties (like partners)
 * `<season>` -- one of `sp`, `fa`, `sum` to indicate when the project is taking place
 * `<2 digit year>` -- the year in two digits
+* `[type]` -- This is an optional field but should be used if the project does have a type. Possible options are, `ds`(Data Science), `se`(Software Engineering), `ml`(Machine Learning), `ux` (UI/UX), and `xcc`(CoLabs/XCCs).
 * `<project>` -- name of the project or class, preferably as short as reasonable
 * `[mgmt]` -- optional, should include only Spark! staff, PMs, and TEs. May include EIRs and Mentors
 * `[inst]` -- optional, should include only instructors and, at the instructor's discretion, others


### PR DESCRIPTION
I updated the doc to have another optional field for the slack naming convention. This one adds one for DS, SE etc projects.